### PR TITLE
xrdcp recursively, plus helper functions

### DIFF
--- a/recursiveFileList.py
+++ b/recursiveFileList.py
@@ -1,0 +1,55 @@
+from os import path, listdir
+# Couldn't find intuitive tools for doing this on teh web
+# John Hakala, 3/28/2017
+
+def mapDir(prefix, directory):
+  thisDir = path.join(prefix, directory)
+  childMap = {}
+  contents = []
+  for child in listdir(thisDir):
+    if path.isfile(path.join(thisDir, child)):
+      contents.append(child)
+    elif path.isdir(path.join(thisDir, child)):
+      contents.append(mapDir(thisDir, child))
+  childMap[directory] = contents
+  return childMap
+  
+def makeFileList(prefix, dirMap):
+  fileList = []
+  for key in dirMap.keys():
+    for child in dirMap[key]:
+      if type(child) is str:
+        fileList.append(path.join(prefix, path.join(key, child)))
+      elif type(child) is dict:
+        for subdirFile in makeFileList(path.join(prefix, key), child):
+          fileList.append(subdirFile)
+  return fileList
+
+def makeDirList(prefix, dirMap):
+  dirList = []
+  for key in dirMap.keys():
+    for child in dirMap[key]:
+      if type(child) is dict:
+        dirList.append(path.join(prefix, path.join(key, child.keys()[0])))
+        for subDir in makeDirList(path.join(prefix, key), child):
+          dirList.append(path.join(path.join(prefix, key), subDir))
+  return dirList
+      
+def getFileList(dirName):
+  return makeFileList(dirName, mapDir(dirName, dirName))
+
+def getDirList(dirName):
+  return makeDirList(dirName, mapDir(dirName, dirName))
+
+if __name__ == "__main__":
+  from sys import argv
+  from pprint import pprint
+  print "--------\nmap:"
+  pprint(mapDir(argv[1], argv[1]))
+  print "--------\n"
+  print "--------\nfiles:"
+  pprint(getFileList(argv[1]))
+  print "--------\n"
+  print "--------\ndirs:"
+  pprint(getDirList(argv[1]))
+  print "--------"

--- a/xrdcpRecursive.py
+++ b/xrdcpRecursive.py
@@ -1,0 +1,26 @@
+from commands import getoutput
+from recursiveFileList import getFileList, getDirList
+from optparse import OptionParser
+
+# recursive copying for xrdcp
+# John Hakala 3/28/2017
+parser = OptionParser()
+parser.add_option("-s", "--source", dest="source",
+                  help="the source directory"      )
+parser.add_option("-t", "--target", dest="target",
+                  help="the target directory"      )
+(options, args) = parser.parse_args()
+
+if options.source is None or options.target is None:
+  print "Error: please define the source and target"
+  parser.print_help()
+  exit(1)
+
+## Apparently this isn't needed on EOS: xrdcp will make any enclosing directories on eos
+#for sourceDir in getDirList(options.source):
+#  targetDir = sourceDir.replace(options.source, options.target)
+#  print getoutput('eosmkdir %s' % targetDir)
+
+for sourceFile in getFileList(options.source):
+  targetFile = sourceFile.replace(options.source, options.target)
+  print getoutput("xrdcp %s root://cmseos.fnal.gov/%s" % (sourceFile, targetFile))


### PR DESCRIPTION
This is to allow transferring of files from a normal filesystem onto eos via xrdcp recursively. It also has some helper methods that are more intuitive than os.walk type techniques for grabbing lists of files within a directory and lists of subdirs within a directory.