### PR TITLE
Scripts dealing with certificates

### DIFF
--- a/copy_certificates
+++ b/copy_certificates
@@ -1,0 +1,60 @@
+#! /bin/bash
+
+proxy_exists(){
+    echo "Check for certificates in $HOME/.globus"
+    echo "..."
+    if [ -d $HOME/.globus ]; then
+        if [ -a $HOME/.globus/usercert.pem ] && [ -a $HOME/.globus/userkey.pem ]; then
+            echo "Certificates exist. Doing nothing."
+            return 0
+        fi
+    fi
+    echo "Couldn't find any certificates."
+    return 1
+}
+
+read -d '' USAGE <<"EOF"
+\\t\\t\\t=================================================================================
+\\t\\t\\tThis script checks if you have globus certificates or lets you
+\\t\\t\\tcopy them from another machine otherwise (default: lxplus.cern.ch)
+\\t\\t\\tNOTE: New certificates need to be requested first. Follow this Twiki for that:
+\\t\\t\\t
+\\t\\t\\thttps://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookStartingGrid#ObtainingCert
+\\t\\t\\t=================================================================================\\n\\n
+EOF
+
+echo -e "$USAGE"
+
+if proxy_exists; then
+    exit
+fi
+
+echo "Copying certificates from another machine"
+echo "Note: This requires certificates to be under the standard \$HOME/.globus location"
+echo -e "...\n\n\n"
+
+hostname='lxplus.cern.ch'
+read -e -p "Enter hostname of machine to login: " -i "lxplus.cern.ch" input
+hostname="${input:-$name}"
+
+
+read -e -p "Enter username for $hostname: " username
+
+if [ ! -d $HOME/.globus ]; then
+    mkdir $HOME/.globus
+fi
+scp -p -r "$username@$hostname:./.globus/*" $HOME/.globus
+
+res=$?
+
+if [ "$res" = "0" ]; then
+ 
+    echo -e "All Done..."
+    echo -e "You can execute the following to initialize your proxy: \n"
+    echo -e "voms-proxy-init -voms cms -valid 192:00"
+else
+    echo -e "There were problems copying the certificate from the remote machine."
+    echo -e "Please, contact us: cms-connect-support@cern.ch"
+fi
+
+exit $res

--- a/copy_certificates
+++ b/copy_certificates
@@ -54,7 +54,7 @@ if [ "$res" = "0" ]; then
     echo -e "voms-proxy-init -voms cms -valid 192:00"
 else
     echo -e "There were problems copying the certificate from the remote machine."
-    echo -e "Please, contact us: cms-connect-support@cern.ch"
+    echo -e "For help you can contact the people listed at http://lpc.fnal.gov/computing/gethelp.shtml"
 fi
 
 exit $res

--- a/getSiteInfo.py
+++ b/getSiteInfo.py
@@ -10,8 +10,7 @@ siteDBDict = {
     'T2_US_Vanderbilt' : ('',                        '',                    'gridftp.accre.vanderbilt.edu', '/lio/lfs/cms/'),
     'T3_US_FNALLPC'    : ('',                        'cmseos.fnal.gov',     '',                             '/eos/uscms/'),
     'T3_US_TAMU'       : ('',                        'srm.brazos.tamu.edu', '',                             '/fdata/hepx/'),
-    'T3_US_UMD'        : ('',                        'hepcms-0.umd.edu',    '',
-         '/mnt/hadoop/cms/')
+    'T3_US_UMD'        : ('',                        'hepcms-0.umd.edu',    '',                             '/mnt/hadoop/cms/')
 }
 
 def is_number(s):

--- a/getSiteInfo.py
+++ b/getSiteInfo.py
@@ -9,7 +9,9 @@ siteDBDict = {
     'T2_CH_CERN'       : ('',                        'eoscms.cern.ch',      '',                             ''),
     'T2_US_Vanderbilt' : ('',                        '',                    'gridftp.accre.vanderbilt.edu', '/lio/lfs/cms/'),
     'T3_US_FNALLPC'    : ('',                        'cmseos.fnal.gov',     '',                             '/eos/uscms/'),
-    'T3_US_TAMU'       : ('',                        'srm.brazos.tamu.edu', '',                             '/fdata/hepx/')
+    'T3_US_TAMU'       : ('',                        'srm.brazos.tamu.edu', '',                             '/fdata/hepx/'),
+    'T3_US_UMD'        : ('',                        'hepcms-0.umd.edu',    '',
+        '')
 }
 
 def is_number(s):

--- a/getSiteInfo.py
+++ b/getSiteInfo.py
@@ -11,7 +11,7 @@ siteDBDict = {
     'T3_US_FNALLPC'    : ('',                        'cmseos.fnal.gov',     '',                             '/eos/uscms/'),
     'T3_US_TAMU'       : ('',                        'srm.brazos.tamu.edu', '',                             '/fdata/hepx/'),
     'T3_US_UMD'        : ('',                        'hepcms-0.umd.edu',    '',
-        '')
+         '/mnt/hadoop/cms/')
 }
 
 def is_number(s):

--- a/install_certificate
+++ b/install_certificate
@@ -1,0 +1,87 @@
+#! /bin/bash
+
+proxy_exists(){
+    echo "Check for certificates in $HOME/.globus ... "
+    if [ -d $HOME/.globus ]; then
+        if [ $1 != "N" ] && [ $1 != "y" ]; then
+			echo -e "\tUnknown option \"$1\". You must specify [y/N] to delete or keep any existing .pem files."
+			return 0
+		elif [ -a $HOME/.globus/usercert.pem ] && [ -a $HOME/.globus/userkey.pem ] && [ $1 == "N" ]; then
+            echo -e "\tCertificates exist. Doing nothing."
+            return 0
+        elif [ -a $HOME/.globus/usercert.pem ] && [ -a $HOME/.globus/userkey.pem ] && [ $1 == "y" ]; then
+			echo -e "\tCertificates exist, but removing them in order to replace them."
+			rm -f $HOME/.globus/usercert.pem
+			rm -f $HOME/.globus/userkey.pem
+			return 1
+		fi
+    fi
+    echo -e "\tCouldn't find any certificates."
+    return 1
+}
+
+read -d '' USAGE <<"EOF"
+\\t\\t\\t=================================================================================
+\\t\\t\\tThis script checks if you have globus certificates or lets you
+\\t\\t\\tinstall them from a p12 file (default: mycert.p12)
+\\t\\t\\tTo overwrite existing certificates you must enter specify that [y/N] (default: N)
+\\t\\t\\tNOTE: New certificates need to be requested first. Follow this Twiki for that:
+\\t\\t\\t
+\\t\\t\\thttps://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookStartingGrid#ObtainingCert
+\\t\\t\\t=================================================================================\\n\\n
+EOF
+
+echo -e "$USAGE"
+
+read -e -p "If certificates already exist would you like to overwrite them? [y/N]: " -i "N" overwrite
+
+if proxy_exists ${overwrite:-$name}; then
+    exit
+fi
+
+cert_file='mycert.p12'
+read -e -p "Enter the full path of the p12 certificate file (default: mycert.p12): " -i "mycert.p12" input
+cert_file="${input:-$name}"
+
+if [ ! -e ${cert_file} ]; then
+	echo -e "\tUnable to find the certificate file ${cert_file}."
+	echo -e "\tNOTE: The home character \"~\" is not expanded and must not be used."
+	exit -1
+fi
+
+echo "Installing certificates from ${cert_file} ... "
+
+if [ ! -d $HOME/.globus ]; then
+    mkdir $HOME/.globus
+	chmod 700 $HOME/.globus
+fi
+
+curdir=$PWD
+cd $HOME/.globus
+
+echo -e "Running the command \`openssl pkcs12 -in ${cert_file} -clcerts -nokeys -out usercert.pem\`"
+openssl pkcs12 -in ${cert_file} -clcerts -nokeys -out usercert.pem
+res=$?
+echo -e "Running the command \`openssl pkcs12 -in ${cert_file} -nocerts -out userkey.pem\`"
+openssl pkcs12 -in ${cert_file} -nocerts -out userkey.pem
+res=$((res + $?))
+chmod 400 userkey.pem
+res=$((res + $?))
+chmod 400 usercert.pem
+res=$((res + $?))
+
+if [ "$res" = "0" ]; then
+
+    echo -e "\nAll Done..."
+    echo -e "You can execute the following to initialize your proxy: \n"
+    echo -e "voms-proxy-init -voms cms -valid 192:00"
+else
+    echo -e "\nThere were problems installing the certificates."
+    echo -e "Please, contact check the directions at "
+	echo -e " https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookStartingGrid#ObtainingCert"
+	echo -e " and try the process manually."
+fi
+
+cd $curdir
+
+exit $res

--- a/install_certificate
+++ b/install_certificate
@@ -3,13 +3,13 @@
 proxy_exists(){
     echo "Check for certificates in $HOME/.globus ... "
     if [ -d $HOME/.globus ]; then
-        if [ $1 != "N" ] && [ $1 != "y" ]; then
-			echo -e "\tUnknown option \"$1\". You must specify [y/N] to delete or keep any existing .pem files."
+        if [ $1 != "N" ] && [ $1 != "Y" ]; then
+			echo -e "\tUnknown option \"$1\". You must specify [Y/N] to delete or keep any existing .pem files."
 			return 0
 		elif [ -a $HOME/.globus/usercert.pem ] && [ -a $HOME/.globus/userkey.pem ] && [ $1 == "N" ]; then
             echo -e "\tCertificates exist. Doing nothing."
             return 0
-        elif [ -a $HOME/.globus/usercert.pem ] && [ -a $HOME/.globus/userkey.pem ] && [ $1 == "y" ]; then
+        elif [ -a $HOME/.globus/usercert.pem ] && [ -a $HOME/.globus/userkey.pem ] && [ $1 == "Y" ]; then
 			echo -e "\tCertificates exist, but removing them in order to replace them."
 			rm -f $HOME/.globus/usercert.pem
 			rm -f $HOME/.globus/userkey.pem
@@ -24,7 +24,7 @@ read -d '' USAGE <<"EOF"
 \\t\\t\\t=================================================================================
 \\t\\t\\tThis script checks if you have globus certificates or lets you
 \\t\\t\\tinstall them from a p12 file (default: mycert.p12)
-\\t\\t\\tTo overwrite existing certificates you must enter specify that [y/N] (default: N)
+\\t\\t\\tTo overwrite existing certificates you must specify that [y/N] (default: N)
 \\t\\t\\tNOTE: New certificates need to be requested first. Follow this Twiki for that:
 \\t\\t\\t
 \\t\\t\\thttps://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookStartingGrid#ObtainingCert
@@ -33,7 +33,7 @@ EOF
 
 echo -e "$USAGE"
 
-read -e -p "If certificates already exist would you like to overwrite them? [y/N]: " -i "N" overwrite
+read -e -p "If certificates already exist would you like to overwrite them? [Y/N]: " -i "N" overwrite
 
 if proxy_exists ${overwrite:-$name}; then
     exit

--- a/install_certificate
+++ b/install_certificate
@@ -77,7 +77,7 @@ if [ "$res" = "0" ]; then
     echo -e "voms-proxy-init -voms cms -valid 192:00"
 else
     echo -e "\nThere were problems installing the certificates."
-    echo -e "Please, contact check the directions at "
+    echo -e "Please, check the directions at "
 	echo -e " https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookStartingGrid#ObtainingCert"
 	echo -e " and try the process manually."
 fi

--- a/make_certificate_file
+++ b/make_certificate_file
@@ -1,0 +1,86 @@
+#! /bin/bash
+
+globus_exists(){
+    echo "Check for the $HOME/.globus folder ... "
+    if [ ! -d $HOME/.globus ]; then
+		echo -e "\tCouldn't find the ${HOME}/.globus folder."
+		return 0
+    fi
+    return 1
+}
+
+certs_exist(){
+	cert_dir=$(dirname "${1}")
+	cert_file=$(basename "${1}")
+	echo "Check for $cert_file in $cert_dir ... "
+	if [ ! -e ${1} ]; then
+		echo -e "\tUnable to find the file ${1}."
+		echo -e "\tNOTE: The home character \"~\" is not expanded and must not be used."
+		return 0
+	fi
+
+	key_dir=$(dirname "${2}")
+	key_file=$(basename "${2}")
+	if [ ! -e ${2} ]; then
+		echo -e"\tUnable to find the file ${2}."
+        echo -e "\tNOTE: The home character \"~\" is not expanded and must not be used."
+        return 0
+    fi
+	
+	echo -e "\tFound both the usercert and userkey files."
+	return 1
+}
+
+read -d '' USAGE <<EOF
+\\t\\t\\t=================================================================================
+\\t\\t\\tThis script checks if you have globus certificates or lets you
+\\t\\t\\tinstall them from a p12 file (default: mycert.p12)
+\\t\\t\\tTo overwrite existing certificates you must enter specify that [y/N] (default: N)
+\\t\\t\\tNOTE: New certificates need to be requested first. Follow this Twiki for that:
+\\t\\t\\t
+\\t\\t\\thttps://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookStartingGrid#ObtainingCert
+\\t\\t\\t=================================================================================\\n\\n
+EOF
+
+echo -e "$USAGE"
+
+if globus_exists; then
+	exit -1
+fi
+
+usercert='${HOME}/.globus/usercert.pem'
+userkey='${HOME}/.globus/userkey.pem'
+read -e -p "Enter the full path of the usercert file: " -i "${HOME}/.globus/usercert.pem" input
+usercert="${input:-$name}"
+read -e -p "Enter the full path of the userkey file: " -i "${HOME}/.globus/userkey.pem" input
+userkey="${input:-$name}"
+if certs_exist $usercert $userkey; then
+	exit -2
+fi
+
+mycert="${HOME}/.globus/mycert.p12"
+desc="my browser cert for <year>"
+read -e -p "Enter the output path and name to the p12 certificate file: " -i "${HOME}/.globus/mycert.p12" input
+mycert="${input:-$name}"
+read -e -p "Enter a description of this certificate file: " -i "my browser cert for <year>" input
+desc="${input:-$name}"
+if [ ! -e $(dirname "${mycert}") ]; then
+	echo -e "\tUnable to find the output path for the certificate file."
+	exit -3
+fi
+
+echo -e "Running the command \`openssl pkcs12 -export -in ${usercert} -inkey ${userkey} -out ${mycert} -name \"${desc}\"\`"
+openssl pkcs12 -export -in ${usercert} -inkey ${userkey} -out ${mycert} -name "${desc}"
+res=$?
+if [ "$res" = "0" ]; then
+
+    echo -e "\nAll Done..."
+    echo -e "You can now import the file ${mycert} into your browser.\n"
+else
+    echo -e "\nThere were problems creating the file ${mycert}."
+    echo -e "Please, contact check the directions at "
+    echo -e " https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookStartingGrid#ObtainingCert"
+    echo -e " and try the process manually."
+fi
+
+exit ${res}

--- a/make_certificate_file
+++ b/make_certificate_file
@@ -78,7 +78,7 @@ if [ "$res" = "0" ]; then
     echo -e "You can now import the file ${mycert} into your browser.\n"
 else
     echo -e "\nThere were problems creating the file ${mycert}."
-    echo -e "Please, contact check the directions at "
+    echo -e "Please, check the directions at "
     echo -e " https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookStartingGrid#ObtainingCert"
     echo -e " and try the process manually."
 fi


### PR DESCRIPTION
Add several utilities (bash scripts) for working with certificate files. copy_certificates will copy the usercert.pem and userkey.pem files from another server (i.e. lxplus) and place them on the current server (i.e. cmslpc). This is a copy of the file maintained by the CMS Connect team. The install_certificate script will take a p12 file and create the usercert.pem and userkey.pem files. The make_certificate_file script will combine the usercert.pem and userkey.pem files into a p12 file which can then be imported into a browser.

There is one additional small change to getSiteInfo, which just adds some xrootd information for T3_US_UMD.