### PR TITLE
Add lfn and pfn information from PhEDEx

### DIFF
--- a/getSiteInfo.py
+++ b/getSiteInfo.py
@@ -3,11 +3,6 @@ import os, sys, getopt, argparse, fnmatch, errno, subprocess, shlex, pycurl, jso
 from StringIO import StringIO
 from collections import namedtuple
 
-# /cvmfs/cms.cern.ch/SITECONF/T1_US_FNAL/PhEDEx/storage.xml
-# Can get site local_redirector and srm endpoints
-# doesn't have eos endpoints
-
-
 siteDBDict = {
 #   alias:               (local_redirector,          'xrootd_endpoint',     'gsiftp_endpoint',              'local_path_to_store')
     'CERNBox'          : ('',                        'eosuser-internal.cern.ch','',                         '/eos/user/<u>/<username>/'),


### PR DESCRIPTION
This PR adds methods to getSiteInfo.py to grab the lfn and pfn information from PhEDEx. Some of this information is undoubtedly redundant to what is stored in the local dictionary. It would be nice to remove the redundant information and then modify copyfiles.py accordingly.

Additionally, a check was added to getSiteInfo.py to make sure the user is on an sl6 machine. I could not get pycurl to work on sl7. It kept complaining about untrusted CA certificates.

@mtonjes @gbenelli @kpedro88 