### PR TITLE
Create CI jobs for linting

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,6 +17,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
+    - name: Print some python and pylint information
+      run: |
+        python --version
+        pylint --version
+        pylint --help
     - name: Analysing the code for python3 compatibility
       run: |
         pylint --py3k `ls -R|grep .py$|xargs`

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,8 +1,6 @@
 name: Lint Code
 
 on: [push, pull_request]
-  branch:
-    - master
 
 jobs:
   pylint:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -19,7 +19,7 @@ jobs:
         pip install pylint
     - name: Analysing the code for python3 compatibility
       run: |
-        pylint -py3k `ls -R|grep .py$|xargs`
+        pylint --py3k `ls -R|grep .py$|xargs`
     - name: Analysing the code for functionality and style
       run: |
         pylint `ls -R|grep .py$|xargs`
@@ -39,4 +39,5 @@ jobs:
       env:
         SHELLCHECK_OPTS: -s bash
       with:
-       format: tty
+        format: tty
+      continue-on-error: true

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,44 @@
+name: Lint Code
+
+on: [push, pull_request]
+  branch:
+    - master
+
+jobs:
+  pylint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+    - name: Analysing the code for python3 compatibility
+      run: |
+        pylint -py3k `ls -R|grep .py$|xargs`
+    - name: Analysing the code for functionality and style
+      run: |
+        pylint `ls -R|grep .py$|xargs`
+
+  shellcheck:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: ShellCheck
+      # https://github.com/marketplace/actions/shellcheck
+      # You may pin to the exact commit or the version.
+      # uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9
+      # uses: ludeeus/action-shellcheck@1.1.0
+      uses: ludeeus/action-shellcheck@master
+      env:
+        SHELLCHECK_OPTS: -s bash
+      with:
+       format: tty

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -3,6 +3,28 @@ name: Lint Code
 on: [push, pull_request]
 
 jobs:
+  python3_compatibility:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 2.7.18
+      uses: actions/setup-python@v2
+      with:
+        python-version: 2.7.18
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+    - name: Print some python and pylint information
+      run: |
+        python --version
+        pylint --version
+    - name: Analysing the code for python3 compatibility
+      run: |
+        pylint --py3k `ls -R|grep .py$|xargs`
+
   pylint:
 
     runs-on: ubuntu-latest
@@ -21,21 +43,18 @@ jobs:
       run: |
         python --version
         pylint --version
-        pylint --help
-    - name: Analysing the code for python3 compatibility
-      run: |
-        pylint --py3k `ls -R|grep .py$|xargs`
     - name: Analysing the code for functionality and style
       run: |
         pylint `ls -R|grep .py$|xargs`
 
-  shellcheck:
+  ShellCheck:
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
     - name: ShellCheck
+      # https://github.com/koalaman/shellcheck
       # https://github.com/marketplace/actions/shellcheck
       # You may pin to the exact commit or the version.
       # uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -64,4 +64,3 @@ jobs:
         SHELLCHECK_OPTS: -s bash
       with:
         format: tty
-      continue-on-error: true


### PR DESCRIPTION
Create GitHub Actions jobs for linting both the python and shell scripts. The python linting will check for python3 compatibility and then check for functionality and style. The shell linting will check for bash compatibility.