### PR TITLE
Improve docs for xrdcp_recursive.py

### DIFF
--- a/xrdcp_recursive.py
+++ b/xrdcp_recursive.py
@@ -4,7 +4,7 @@
 
 Note to users: This is not to be used for xrdcp'ing files from an XRootD source to a local directory,
 nor from an XRootD source to an XRootD endpoint. For those kinds of transfers, XRootD already supports
-them with the command `xrdcp -r'. 
+them with the command `xrdcp -r'.
 
 Created by: John Hakala, 03/28/2017
 Modified by: Alexx Perloff, 10/02/2021


### PR DESCRIPTION
Based on some feedback from a user, I added some words of warning to the docstring of xrdcp_recursive (explaining that transfers with an xrootd source can be transferred with just `xrdcp -r` instead of needing this script). I also improved the help message so that the docstring is displayed if a user passes the `--help` argument on the command line.