### PR TITLE
Usage of condor within containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,41 @@
 # lpc-scripts
 scripts of use on the cmslpc cluster
 
+## `pipe_condor.sh`
+
+HTCondor commands are installed on cmslpc interactive nodes, but by default they are not accessible inside containers.
+
+The script [pipe_condor.sh](./pipe_condor.sh) enables calling HTCondor commands *on the host node* from inside a container.
+
+### Usage
+
+In your `.bashrc`:
+```bash
+source pipe_condor.sh
+```
+
+Starting a container (the arguments are necessary for your `.bashrc` to be loaded inside the container):
+```bash
+cmssw-el7 -- /bin/bash
+```
+
+### Details
+
+What happens:
+* The `apptainer` command is replaced with a function that will create a set of pipes on the host node before running `apptainer`.
+* Inside the container, all executables starting with `condor_` will automatically run on the host node.
+* To run other commands on the host node, use `call_host cmd`, where `cmd` is the command you want to run (with any arguments).
+
+Options:
+* Before sourcing the script in your `.bashrc`, you can add this line to change the directory where the pipes will be created (the default is `~/nobackup/pipes`):
+    ```bash
+    export PIPE_CONDOR_DIR=your_dir
+    ```
+* If you want to temporarily disable this for a specific container invocation:
+    ```bash
+    PIPE_CONDOR_DISABLE=1 cmssw-el7 ...
+    ````
+
 ## Unit and Integration testing
 
 ### Automated

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ In your `.bashrc`:
 source pipe_condor.sh
 ```
 
+Whenever you edit your `.bashrc`, you should log out and log back in for the changes to take effect.
+
+To check if this line in your `.bashrc` is being executed when you log in, make sure the following command shows some output:
+```bash
+echo $APPTAINERENV_APPTAINER_ORIG
+```
+
 Starting a container (the arguments are necessary for your `.bashrc` to be loaded inside the container):
 ```bash
 cmssw-el7 -- /bin/bash

--- a/README.md
+++ b/README.md
@@ -31,9 +31,17 @@ Options:
     ```bash
     export PIPE_CONDOR_DIR=your_dir
     ```
-* If you want to temporarily disable this for a specific container invocation:
+* If you want to disable this by default and only enable it on the fly, put this line in your `.bashrc`:
     ```bash
-    PIPE_CONDOR_DISABLE=1 cmssw-el7 ...
+    export PIPE_CONDOR_STATUS=${PIPE_CONDOR_STATUS:=disable}
+    ```
+    Then to enable it temporarily:
+    ```bash
+    PIPE_CONDOR_STATUS=enable cmssw-el7 ...
+    ```
+* Instead, if you have this enabled by default and you want to temporarily disable this for a specific container invocation:
+    ```bash
+    PIPE_CONDOR_STATUS=disable cmssw-el7 ...
     ````
 
 ## `bind_condor.sh`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,41 @@ Options:
     PIPE_CONDOR_DISABLE=1 cmssw-el7 ...
     ````
 
+## `bind_condor.sh`
+
+It is also possible to use the HTCondor Python bindings inside a container.
+This requires correctly specifying the HTCondor configuration.
+A simple approach is provided in [bind_condor.sh](./bind_condor.sh).
+
+### Usage
+
+In your `.bashrc`:
+```bash
+source bind_condor.sh
+```
+That's it!
+
+### Setting up bindings
+
+You will also need to have the HTCondor Python bindings installed in your working environment.
+
+Here is an example of how to do this in `CMSSW_10_6_X`, the Run 2 ultra-legacy analysis release that is only available for EL7 operating systems:
+```bash
+cmsrel CMSSW_10_6_30
+cd CMSSW_10_6_30/src
+cmsenv
+scram-venv
+cmsenv
+pip3 install --upgrade pip
+cmsenv
+pip3 install --upgrade htcondor==10.3.0
+```
+In this particular case, it is necessary to upgrade `pip` and install a specific version of the bindings
+because the Python version in `CMSSW_10_6_X` is old (Python 3.6.4).
+
+**NOTE**: This recipe only installs the bindings for Python3, whereas Python2 was still the default in `CMSSW_10_6_X`.
+You will need to make sure any scripts using the bindings are compatible with Python3.
+
 ## Unit and Integration testing
 
 ### Automated

--- a/README.md
+++ b/README.md
@@ -81,7 +81,17 @@ That's it!
 
 You will also need to have the HTCondor Python bindings installed in your working environment.
 
-Here is an example of how to do this in `CMSSW_10_6_X`, the Run 2 ultra-legacy analysis release that is only available for EL7 operating systems:
+For newer CMSSW versions, the installation procedure is simple:
+```bash
+cmsrel CMSSW_X_Y_Z
+cd CMSSW_X_Y_Z/src
+cmsenv
+scram-venv
+cmsenv
+pip3 install htcondor
+```
+
+For `CMSSW_10_6_X`, the Run 2 ultra-legacy analysis release that is only available for EL7 operating systems, there are some extra steps:
 ```bash
 cmsrel CMSSW_10_6_30
 cd CMSSW_10_6_30/src
@@ -95,7 +105,7 @@ pip3 install --upgrade htcondor==10.3.0
 In this particular case, it is necessary to upgrade `pip` and install a specific version of the bindings
 because the Python version in `CMSSW_10_6_X` is old (Python 3.6.4).
 
-**NOTE**: This recipe only installs the bindings for Python3, whereas Python2 was still the default in `CMSSW_10_6_X`.
+**NOTE**: These recipes only install the bindings for Python3. (Python2 was still the default in `CMSSW_10_6_X`.)
 You will need to make sure any scripts using the bindings are compatible with Python3.
 
 ## Unit and Integration testing

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ scram-venv
 cmsenv
 pip3 install htcondor
 ```
+(Click [here](http://cms-sw.github.io/venv.html) to learn more about `scram-venv`)
 
 For `CMSSW_10_6_X`, the Run 2 ultra-legacy analysis release that is only available for EL7 operating systems, there are some extra steps:
 ```bash

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ Options:
     PIPE_CONDOR_STATUS=disable cmssw-el7 ...
     ````
 
+Caveats:
+* cmslpc autodetection of the correct operating system for jobs is currently based on the host OS. Therefore, if you are submitting jobs in a container with a different OS, you will have to manually specify in your JDL file (the `X` in `condor_submit X`):
+    ```
+    +DesiredOS = SL7
+    ```
+    (other possible values are EL8 or EL9)
+* if you are running in a non-RHEL container, then you should manually set a different line in your JDL file:
+    ```
+    +ApptainerImage = "/path/to/your/container"
+    ```
+* CMS connect support is planned, but has not been tested yet.
+
 ## `bind_condor.sh`
 
 It is also possible to use the HTCondor Python bindings inside a container.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ What happens:
 * The `apptainer` command is replaced with a function that will create a set of pipes on the host node before running `apptainer`.
 * Inside the container, all executables starting with `condor_` will automatically run on the host node.
 * To run other commands on the host node, use `call_host cmd`, where `cmd` is the command you want to run (with any arguments).
+* Nested containers are supported (the enable/disable status (see "Options" just below) is inherited from the top-level container and cannot be changed)
 
 Options:
 * Before sourcing the script in your `.bashrc`, you can add this line to change the directory where the pipes will be created (the default is `~/nobackup/pipes`):

--- a/bind_condor.sh
+++ b/bind_condor.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+BIND_CONDOR_CONFIG=/etc/condor/config.d/01_cmslpc_interactive
+BIND_CONDOR_PY=/usr/local/bin/cmslpc-local-conf.py
+export APPTAINER_BIND=${APPTAINER_BIND}${APPTAINER_BIND:+,}${BIND_CONDOR_CONFIG},${BIND_CONDOR_PY}
+
+export APPTAINERENV_CONDOR_CONFIG=/etc/condor/config.d/01_cmslpc_interactive

--- a/pipe_condor.sh
+++ b/pipe_condor.sh
@@ -61,6 +61,7 @@ export -f call_host
 copy_function() {
 	test -n "$(declare -f "$1")" || return
 	eval "${_/$1/$2}"
+	eval "export -f $2"
 }
 export -f copy_function
 

--- a/pipe_condor.sh
+++ b/pipe_condor.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# concept based on https://stackoverflow.com/questions/32163955/how-to-run-shell-script-on-host-from-docker-container
+
+# execute command sent to host pipe; send output to container pipe; send terminating string when command finishes
+listenhost(){
+	# stop when host pipe is removed
+	while [ -e $1 ]; do
+		# "|| true" is necessary to stop "Interrupted system call"
+		# must be *inside* eval to ensure EOF once command finishes
+		eval "$(cat $1) || true" >& $2
+	done
+}
+export -f listenhost
+
+# creates randomly named pipe and prints the name
+makepipe(){
+	PREFIX=$1
+	PIPETMP=$(readlink -f ~/nobackup/${PREFIX}_$(uuidgen))
+	mkfifo $PIPETMP
+	echo $PIPETMP
+}
+export -f makepipe
+
+# to be run on host before launching each apptainer session
+startpipe(){
+	HOSTPIPE=$(makepipe HOST)
+	CONTPIPE=$(makepipe CONT)
+	# export HOSTPIPE and CONTPIPE to apptainer
+	echo "export APPTAINERENV_HOSTPIPE=$HOSTPIPE; export APPTAINERENV_CONTPIPE=$CONTPIPE"
+}
+export -f startpipe
+
+# sends function to host, then listens for output
+call_host(){
+	if [ "$FUNCNAME" = "call_host" ]; then
+		FUNCTMP=
+	else
+		FUNCTMP=$FUNCNAME
+	fi
+	echo "cd $PWD; $FUNCTMP $@" > $HOSTPIPE
+	cat < $CONTPIPE
+}
+export -f call_host
+
+# from https://stackoverflow.com/questions/1203583/how-do-i-rename-a-bash-function
+copy_function() {
+	test -n "$(declare -f "$1")" || return
+	eval "${_/$1/$2}"
+}
+export -f copy_function
+
+# set this default on host, but not in container (in case overridden)
+if [ -z "$APPTAINER_CONTAINER" ]; then
+	export DISABLE_PIPE_CONDOR=0
+fi
+if [ -z "$APPTAINER_ORIG" ]; then
+	export APPTAINER_ORIG=$(which apptainer)
+fi
+apptainer(){
+	if [ "$DISABLE_PIPE_CONDOR" -eq 1 ]; then
+		(
+		export APPTAINERENV_DISABLE_PIPE_CONDOR=1
+		$APPTAINER_ORIG "$@"
+		)
+	else
+		# in subshell to contain exports
+		(
+		eval $(startpipe)
+		listenhost $APPTAINERENV_HOSTPIPE $APPTAINERENV_CONTPIPE &
+		LISTENER=$!
+		$APPTAINER_ORIG "$@"
+		# avoid dangling cat process after exiting container
+		pkill -P $LISTENER
+		rm -f $APPTAINERENV_HOSTPIPE $APPTAINERENV_CONTPIPE
+		)
+	fi
+}
+export -f apptainer
+
+# on host: get list of condor executables
+if [ -z "$APPTAINER_CONTAINER" ]; then
+	export APPTAINERENV_HOSTFNS=$(compgen -c | grep ^condor_)
+# in container: replace with call_host versions
+elif [ "$DISABLE_PIPE_CONDOR" -ne 1 ]; then
+	for HOSTFN in $HOSTFNS; do
+		copy_function call_host $HOSTFN
+	done
+	# cleanup
+	trap "rm -f $HOSTPIPE $CONTPIPE" EXIT
+fi

--- a/pipe_condor.sh
+++ b/pipe_condor.sh
@@ -71,6 +71,8 @@ fi
 if [ -z "$APPTAINER_ORIG" ]; then
 	export APPTAINER_ORIG=$(which apptainer)
 fi
+# always set this (in case of nested containers)
+export APPTAINERENV_APPTAINER_ORIG=$APPTAINER_ORIG
 apptainer(){
 	if [ "$PIPE_CONDOR_DISABLE" -eq 1 ]; then
 		(


### PR DESCRIPTION
This PR introduces two methods to use condor while inside containers:
1. Using pipes to run condor commands on the host node while inside a container
2. Importing the host condor configuration into the container and installing the python bindings locally

Known issues:
* The automatic OS detection on cmslpc does not know about containers, so you have to specify the desired OS and/or container manually in the job description file.
* Support for other (non-cmslpc) clusters is not included yet.