### PR TITLE
Condor script updates

### DIFF
--- a/bind_condor.sh
+++ b/bind_condor.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+bind_if_exists(){
+	for ITEM in "$@"; do
+		TESTITEM="${ITEM%%:*}"
+		if [ -e "$TESTITEM" ]; then
+			export APPTAINER_BIND=${APPTAINER_BIND}${APPTAINER_BIND:+,}${ITEM}
+		fi
+	done
+}
+
 LPC_CONDOR_CONFIG=/etc/condor/config.d/01_cmslpc_interactive
 LPC_CONDOR_LOCAL=/usr/local/bin/cmslpc-local-conf.py
 
@@ -12,18 +21,18 @@ if [ "$COMMAND_NAME" = "$(basename $LPC_CONDOR_LOCAL)" ]; then
 fi
 
 OSG_CONDOR_CONFIG=/etc/condor/condor_config
-OSG_CONDOR_LOCAL=/usr/share/condor/config.d,/etc/condor/config.d
+OSG_CONDOR_LOCAL=(/usr/share/condor/config.d /etc/condor/config.d)
 
 LXP_CONDOR_CONFIG=/etc/condor/condor_config
-LXP_CONDOR_LOCAL=/etc/condor/config.d,/usr/bin/myschedd.sh,/usr/bin/myschedd,/etc/myschedd
+LXP_CONDOR_LOCAL=(/etc/condor/config.d /usr/bin/myschedd.sh /usr/bin/myschedd /etc/myschedd)
 
 if [[ "$(uname -a)" == *cms*.fnal.gov* ]]; then
-	export APPTAINER_BIND=${APPTAINER_BIND}${APPTAINER_BIND:+,}${LPC_CONDOR_CONFIG},${LPC_CONDOR_LOCAL}:${LPC_CONDOR_LOCAL}.orig,${COMMAND_PATH}:${LPC_CONDOR_LOCAL}
+	bind_if_exists ${LPC_CONDOR_CONFIG} ${LPC_CONDOR_LOCAL}:${LPC_CONDOR_LOCAL}.orig "${COMMAND_PATH}":${LPC_CONDOR_LOCAL}
 	export APPTAINERENV_CONDOR_CONFIG=${LPC_CONDOR_CONFIG}
 elif [[ "$(uname -a)" == *.uscms.org* ]] || [[ "$(uname -a)" == *.osg-htc.org* ]]; then
-	export APPTAINER_BIND=${APPTAINER_BIND}${APPTAINER_BIND:+,}${OSG_CONDOR_CONFIG},${OSG_CONDOR_LOCAL}
+	bind_if_exists ${OSG_CONDOR_CONFIG} "${OSG_CONDOR_LOCAL[@]}"
 	export APPTAINERENV_CONDOR_CONFIG=${OSG_CONDOR_CONFIG}
 elif [[ "$(uname -a)" == *lxplus*.cern.ch* ]]; then
-	export APPTAINER_BIND=${APPTAINER_BIND}${APPTAINER_BIND:+,}${LXP_CONDOR_CONFIG},${LXP_CONDOR_LOCAL}
+	bind_if_exists ${LXP_CONDOR_CONFIG} "${LXP_CONDOR_LOCAL[@]}"
 	export APPTAINERENV_CONDOR_CONFIG=${LXP_CONDOR_CONFIG}
 fi

--- a/bind_condor.sh
+++ b/bind_condor.sh
@@ -29,7 +29,7 @@ LXP_CONDOR_LOCAL=(/etc/condor/config.d /usr/bin/myschedd.sh /usr/bin/myschedd /e
 if [[ "$(uname -a)" == *cms*.fnal.gov* ]]; then
 	bind_if_exists ${LPC_CONDOR_CONFIG} ${LPC_CONDOR_LOCAL}:${LPC_CONDOR_LOCAL}.orig "${COMMAND_PATH}":${LPC_CONDOR_LOCAL}
 	export APPTAINERENV_CONDOR_CONFIG=${LPC_CONDOR_CONFIG}
-elif [[ "$(uname -a)" == *.uscms.org* ]] || [[ "$(uname -a)" == *.osg-htc.org* ]]; then
+elif [[ "$(uname -a)" == *.uscms.org* ]] || [[ "$(uname -a)" == *.osg-htc.org* ]] || [[ "$(uname -a)" == *cmscon.hep.wisc.edu* ]]; then
 	bind_if_exists ${OSG_CONDOR_CONFIG} "${OSG_CONDOR_LOCAL[@]}"
 	export APPTAINERENV_CONDOR_CONFIG=${OSG_CONDOR_CONFIG}
 elif [[ "$(uname -a)" == *lxplus*.cern.ch* ]]; then

--- a/call_host.sh
+++ b/call_host.sh
@@ -19,7 +19,7 @@ fi
 if [ -z "$CALL_HOST_DIR" ]; then
 	if [[ "$(uname -a)" == *cms*.fnal.gov* ]]; then
 		export CALL_HOST_DIR=~/nobackup/pipes
-	elif [[ "$(uname -a)" == *.uscms.org* ]] || [[ "$(uname -a)" == *.osg-htc.org* ]] ; then
+	elif [[ "$(uname -a)" == *.uscms.org* ]] || [[ "$(uname -a)" == *.osg-htc.org* ]] || [[ "$(uname -a)" == *cmscon.hep.wisc.edu* ]]; then
 		export CALL_HOST_DIR=/scratch/$(whoami)/pipes
 	elif [[ "$(uname -a)" == *lxplus*.cern.ch* ]]; then
 		export CALL_HOST_DIR=/tmp/$(whoami)/pipes


### PR DESCRIPTION
1. prevent errors when `bind_condor.sh` is used but a given node does not have condor installed (e.g. the LPC gpu nodes)
2. update CMS connect hostname