### PR TITLE
Call host fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ or placed in a file `~/.callhostrc` (automatically detected and sourced by `call
     The symptom of this will be that subsequent host commands hang, and pressing ctrl+C will give the error message "Interrupted system call".
     It is necessary to exit and reenter the container (in order to create a new pipe) if this occurs.
     To avoid this, chain multiple commands using logical operators (`&&` or `||`), or surround all the commands in `()` (thereby running them in a subshell).
-* Stopping a command in progress with ctrl+C will also break the pipe (as described in the previous item).
+* Stopping a command in progress with ctrl+C is disabled (to avoid breaking the pipe as described in the previous item).
+* Suspending a command with ctrl+Z is not supported and may break the session.
 
 ## `bind_condor.sh`
 

--- a/README.md
+++ b/README.md
@@ -135,10 +135,9 @@ or placed in a file `~/.callhostrc` (automatically detected and sourced by `call
     ```
 * Using the `ENV()` function in the JDL file may not function as intended, since it will be evaluated on the host node, rather than inside the container with your environment set up.
 * Commands that require tty input (such as `nano` or `emacs -nw`) will not work with `call_host`.
-* Calling multiple commands at once with `call_host` can break the pipe if the commands are separated by semicolons and a non-final command fails.
-    The symptom of this will be that subsequent host commands hang, and pressing ctrl+C will give the error message "Interrupted system call".
+* Occasionally, if a command fails (especially when calling multiple commands separated by semicolons), the pipe will break and the terminal will appear to hang. The message "Interrupted system call" may be shown.
     It is necessary to exit and reenter the container (in order to create a new pipe) if this occurs.
-    To avoid this, chain multiple commands using logical operators (`&&` or `||`), or surround all the commands in `()` (thereby running them in a subshell).
+    To prevent this, chain multiple commands using logical operators (`&&` or `||`), or surround all the commands in `()` (thereby running them in a subshell).
 * Stopping a command in progress with ctrl+C is disabled (to avoid breaking the pipe as described in the previous item).
 * Suspending a command with ctrl+Z is not supported and may break the session.
 

--- a/call_host.sh
+++ b/call_host.sh
@@ -4,7 +4,7 @@
 # check for configuration
 CALL_HOST_CONFIG=~/.callhostrc
 if [ -f "$CALL_HOST_CONFIG" ]; then
-    # shellcheck source=/dev/null
+	# shellcheck source=/dev/null
 	source "$CALL_HOST_CONFIG"
 fi
 
@@ -89,6 +89,8 @@ export -f startpipe
 
 # sends function to host, then listens for output, and provides exit code from function
 call_host(){
+	# disable ctrl+c to prevent "Interrupted system call"
+	trap "" SIGINT
 	if [ "${FUNCNAME[0]}" = "call_host" ]; then
 		FUNCTMP=
 	else

--- a/call_host.sh
+++ b/call_host.sh
@@ -140,6 +140,7 @@ apptainer(){
 		if [ -z "$APPTAINER_CONTAINER" ]; then
 			pkill -P "$LISTENER"
 			rm -f "$APPTAINERENV_HOSTPIPE" "$APPTAINERENV_CONTPIPE" "$APPTAINERENV_EXITPIPE"
+			kill "$LISTENER"
 		fi
 		)
 	fi


### PR DESCRIPTION
The changes here eliminate most sources of "Interrupted system call" errors. It is still observed to happen occasionally, so the documentation of these errors is preserved.